### PR TITLE
Use same category id across datasets

### DIFF
--- a/labelme2coco/__init__.py
+++ b/labelme2coco/__init__.py
@@ -4,6 +4,8 @@ __version__ = "0.1.2"
 
 from labelme2coco.labelme2coco import labelme2coco
 
+def converter():
+    return labelme2coco()
 
 def convert(labelme_folder: str, save_json_path: str):
     """
@@ -11,4 +13,4 @@ def convert(labelme_folder: str, save_json_path: str):
         labelme_folder: folder that contains labelme annotations and image files
         save_json_path: oath for coco json to be saved
     """
-    labelme2coco(labelme_folder, save_json_path)
+    labelme2coco().convert(labelme_folder, save_json_path)

--- a/labelme2coco/labelme2coco.py
+++ b/labelme2coco/labelme2coco.py
@@ -8,7 +8,12 @@ from labelme2coco.image_utils import read_image_shape_as_dict
 
 
 class labelme2coco(object):
-    def __init__(self, labelme_folder='', save_json_path='./new.json'):
+    def __init__(self):
+        # Retains categories for different datasets. e.g. train and validation set
+        self.categories = []
+        self.label = []
+
+    def convert(self, labelme_folder='', save_json_path='./new.json'):
         """
         Args:
             labelme_folder: folder that contains labelme annotations and image files
@@ -16,9 +21,7 @@ class labelme2coco(object):
         """
         self.save_json_path = save_json_path
         self.images = []
-        self.categories = []
         self.annotations = []
-        self.label = []
         self.annID = 1
         self.height = 0
         self.width = 0


### PR DESCRIPTION
I want my dataset folder structure to be like coco dataset
```
root
|--  train
|--|-- train images
|-- validation
|--|-- validation images
```
I needed to use same category information (id) across train and validation annotation, so I modified the code a little bit.
It can be used as:
```python
converter = labelme2coco.converter()
converter.convert(train_folder, train_json_path)
converter.convert(val_folder, val_json_path)
```
I hope it would be helpful change to others, too.
