### PR TITLE
Use the labelme sizes instead of recomputing them

### DIFF
--- a/labelme2coco/labelme2coco.py
+++ b/labelme2coco/labelme2coco.py
@@ -2,7 +2,6 @@ from pathlib import Path
 from typing import List
 
 import numpy as np
-from PIL import Image
 from sahi.utils.coco import Coco, CocoAnnotation, CocoCategory, CocoImage
 from sahi.utils.file import list_files_recursively, load_json, save_json
 from tqdm import tqdm
@@ -41,7 +40,10 @@ def get_coco_from_labelme_folder(
         data = load_json(json_path)
         # get image size
         image_path = str(Path(labelme_folder) / data["imagePath"])
-        width, height = Image.open(image_path).size
+        # use the image sizes provided by labelme (they already account for
+        # things such as EXIF orientation)
+        width = data["imageWidth"]
+        height = data["imageHeight"]
         # init coco image
         coco_image = CocoImage(file_name=data["imagePath"], height=height, width=width)
         # iterate over annotations


### PR DESCRIPTION
In case of annotated images that have EXIF orientation,  labelme would annotate the transformed image and provide the annotation coordinates in the re-oriented image. When computing the image sizes with `Image.open`, we ignore the EXIF orientation and thus save a different image dimension than the one in the labelme file (we swap the dimensions). Since we only use PIL to compute the image sizes and the labelme file provides these dimensions anyway, maybe we can just get away with using them.