### PR TITLE
Support skipping labels

### DIFF
--- a/labelme2coco/__init__.py
+++ b/labelme2coco/__init__.py
@@ -10,6 +10,8 @@ from sahi.utils.file import save_json
 
 from labelme2coco.labelme2coco import get_coco_from_labelme_folder
 
+from typing import List
+
 logger = logging.getLogger(__name__)
 logging.basicConfig(
     format="%(asctime)s - %(levelname)s - %(name)s -   %(message)s",
@@ -22,6 +24,7 @@ def convert(
     labelme_folder: str,
     export_dir: str = "runs/labelme2coco/",
     train_split_rate: float = 1,
+    skip_labels: List[str] = [],
 ):
     """
     Args:
@@ -29,7 +32,7 @@ def convert(
         export_dir: path for coco jsons to be exported
         train_split_rate: ration fo train split
     """
-    coco = get_coco_from_labelme_folder(labelme_folder)
+    coco = get_coco_from_labelme_folder(labelme_folder, skip_labels=skip_labels)
     if train_split_rate < 1:
         result = coco.split_coco_as_train_val(train_split_rate)
         # export train split

--- a/labelme2coco/labelme2coco.py
+++ b/labelme2coco/labelme2coco.py
@@ -15,7 +15,7 @@ class labelme2coco:
 
 
 def get_coco_from_labelme_folder(
-    labelme_folder: str, coco_category_list: List = None
+    labelme_folder: str, coco_category_list: List = None, skip_labels: List[str] = []
 ) -> Coco:
     """
     Args:
@@ -32,6 +32,9 @@ def get_coco_from_labelme_folder(
 
     if coco_category_list is not None:
         coco.add_categories_from_coco_category_list(coco_category_list)
+
+    if len(skip_labels) > 0:
+        print(f"Will skip the following annotated labels: {skip_labels}")
 
     # parse labelme annotations
     category_ind = 0
@@ -51,6 +54,8 @@ def get_coco_from_labelme_folder(
         for shape in data["shapes"]:
             # set category name and id
             category_name = shape["label"]
+            if category_name in skip_labels:
+                continue
             category_id = None
             for (
                 coco_category_id,


### PR DESCRIPTION
I found this helpful, so I'm sharing it with the others.

This allows to skip one or more labels from the annotations, leaving them out from the resulting COCO-friendly JSON.

Usage example:

```bash
labelme2coco path/to/labelme/dir --train_split_rate 0.85 --skip_labels "test1","test2"
```

@fcakyon would you consider opening the "Issues" on this repository to file bugs? (e.g. unit tests are broken)