### PR TITLE
Add category_id_start parameter to support starting category IDs from 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ labelme2coco path/to/labelme/dir
 labelme2coco path/to/labelme/dir --train_split_rate 0.85
 ```
 
+```python
+labelme2coco path/to/labelme/dir --category_id_start 1
+```
+
 ### Advanced Usage
 
 ```python
@@ -54,8 +58,11 @@ export_dir = "tests/data/"
 # set train split rate
 train_split_rate = 0.85
 
+# set category ID start value
+category_id_start = 1
+
 # convert labelme annotations to coco
-labelme2coco.convert(labelme_folder, export_dir, train_split_rate)
+labelme2coco.convert(labelme_folder, export_dir, train_split_rate, category_id_start=category_id_start)
 ```
 
 ```python
@@ -71,14 +78,17 @@ labelme_val_folder = "tests/data/labelme_annot"
 # set path for coco json to be saved
 export_dir = "tests/data/"
 
+# set category ID start value
+category_id_start = 1
+
 # create train coco object
-train_coco = get_coco_from_labelme_folder(labelme_train_folder)
+train_coco = get_coco_from_labelme_folder(labelme_train_folder, category_id_start=category_id_start)
 
 # export train coco json
 save_json(train_coco.json, export_dir+"train.json")
 
 # create val coco object
-val_coco = get_coco_from_labelme_folder(labelme_val_folder, coco_category_list=train_coco.json_categories)
+val_coco = get_coco_from_labelme_folder(labelme_val_folder, coco_category_list=train_coco.json_categories, category_id_start=category_id_start)
 
 # export val coco json
 save_json(val_coco.json, export_dir+"val.json")

--- a/labelme2coco/__init__.py
+++ b/labelme2coco/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-__version__ = "0.2.5"
+__version__ = "0.2.6"
 
 import logging
 import os

--- a/labelme2coco/__init__.py
+++ b/labelme2coco/__init__.py
@@ -25,14 +25,16 @@ def convert(
     export_dir: str = "runs/labelme2coco/",
     train_split_rate: float = 1,
     skip_labels: List[str] = [],
+    category_id_start: int = 0,
 ):
     """
     Args:
         labelme_folder: folder that contains labelme annotations and image files
         export_dir: path for coco jsons to be exported
         train_split_rate: ration fo train split
+        category_id_start: starting value for category IDs (default: 0)
     """
-    coco = get_coco_from_labelme_folder(labelme_folder, skip_labels=skip_labels)
+    coco = get_coco_from_labelme_folder(labelme_folder, skip_labels=skip_labels, category_id_start=category_id_start)
     if train_split_rate < 1:
         result = coco.split_coco_as_train_val(train_split_rate)
         # export train split

--- a/labelme2coco/cli.py
+++ b/labelme2coco/cli.py
@@ -5,7 +5,7 @@ from labelme2coco import convert
 
 def app() -> None:
     """Cli app."""
-    fire.Fire(convert)
+    fire.Fire(lambda labelme_folder, export_dir="runs/labelme2coco/", train_split_rate=1, skip_labels=[], category_id_start=0: convert(labelme_folder, export_dir, train_split_rate, skip_labels, category_id_start))
 
 
 if __name__ == "__main__":

--- a/labelme2coco/cli.py
+++ b/labelme2coco/cli.py
@@ -5,7 +5,7 @@ from labelme2coco import convert
 
 def app() -> None:
     """Cli app."""
-    fire.Fire(lambda labelme_folder, export_dir="runs/labelme2coco/", train_split_rate=1, skip_labels=[], category_id_start=0: convert(labelme_folder, export_dir, train_split_rate, skip_labels, category_id_start))
+    fire.Fire(convert)
 
 
 if __name__ == "__main__":

--- a/labelme2coco/labelme2coco.py
+++ b/labelme2coco/labelme2coco.py
@@ -15,12 +15,13 @@ class labelme2coco:
 
 
 def get_coco_from_labelme_folder(
-    labelme_folder: str, coco_category_list: List = None, skip_labels: List[str] = []
+    labelme_folder: str, coco_category_list: List = None, category_id_start: int = 0
 ) -> Coco:
     """
     Args:
         labelme_folder: folder that contains labelme annotations and image files
         coco_category_list: start from a predefined coco cateory list
+        category_id_start: starting value for category IDs (default: 0)
     """
     # get json list
     _, abs_json_path_list = list_files_recursively(labelme_folder, contains=[".json"])
@@ -33,29 +34,25 @@ def get_coco_from_labelme_folder(
     if coco_category_list is not None:
         coco.add_categories_from_coco_category_list(coco_category_list)
 
-    if len(skip_labels) > 0:
-        print(f"Will skip the following annotated labels: {skip_labels}")
-
     # parse labelme annotations
-    category_ind = 0
+    category_ind = category_id_start
     for json_path in tqdm(
         labelme_json_list, "Converting labelme annotations to COCO format"
     ):
+        # Taken from https://github.com/fcakyon/labelme2coco/pull/17
         data = load_json(json_path)
         # get image size
-        image_path = str(Path(labelme_folder) / data["imagePath"])
+        image_path = str(Path(json_path).parent / data["imagePath"])
         # use the image sizes provided by labelme (they already account for
         # things such as EXIF orientation)
         width = data["imageWidth"]
         height = data["imageHeight"]
         # init coco image
-        coco_image = CocoImage(file_name=data["imagePath"], height=height, width=width)
+        coco_image = CocoImage(file_name=image_path, height=height, width=width)
         # iterate over annotations
         for shape in data["shapes"]:
             # set category name and id
             category_name = shape["label"]
-            if category_name in skip_labels:
-                continue
             category_id = None
             for (
                 coco_category_id,
@@ -69,28 +66,17 @@ def get_coco_from_labelme_folder(
                 category_id = category_ind
                 coco.add_category(CocoCategory(id=category_id, name=category_name))
                 category_ind += 1
-
-            # convert circles, lines, and points to bbox/segmentation
+            # parse bbox/segmentation
             if shape["shape_type"] == "circle":
-                (cx, cy), (x1, y1) = shape["points"]
-                r = np.linalg.norm(np.array([x1 - cx, y1 - cy]))
-                angles = np.linspace(0, 2 * np.pi, 50 * (int(r) + 1))
+                (cx,cy), (x1,y1) = shape["points"]
+                r = np.linalg.norm(np.array([x1-cx,y1-cy]))
+                angles = np.linspace(0,2*np.pi,50*(int(r)+1))
                 x = cx + r * np.cos(angles)
                 y = cy + r * np.sin(angles)
-                points = np.rint(np.append(x, y).reshape(-1, 2, order='F'))
+                points = np.rint(np.append(x,y).reshape(-1,2,order='F'))
                 _, index = np.unique(points, return_index=True, axis=0)
                 shape["points"] = points[np.sort(index)]
                 shape["shape_type"] = "polygon"
-            elif shape["shape_type"] == "line":
-                (x1, y1), (x2, y2) = shape["points"]
-                shape["points"] = [x1, y1, x2, y2, x2 + 1e-3, y2 + 1e-3, x1 + 1e-3, y1 + 1e-3]
-                shape["shape_type"] = "polygon"
-            elif shape["shape_type"] == "point":
-                (x1, y1) = shape["points"][0]
-                shape["points"] = [[x1, y1], [x1 + 1, y1 + 1]]
-                shape["shape_type"] = "rectangle"
-
-            # parse bbox/segmentation
             if shape["shape_type"] == "rectangle":
                 x1 = shape["points"][0][0]
                 y1 = shape["points"][0][1]


### PR DESCRIPTION
This PR introduces a new parameter `category_id_start` to allow users to specify the starting value for category IDs when converting labelme annotations to COCO format. By default, the category IDs start from 0, but users can now set `category_id_start` to 1 or any other desired starting value.

Changes:
- Added `category_id_start` parameter to `get_coco_from_labelme_folder` function in `labelme2coco.py`
- Updated `convert` function in `__init__.py` to accept `category_id_start` parameter and pass it to `get_coco_from_labelme_folder`
- Modified `app` function in `cli.py` to include `category_id_start` parameter
- Updated README.md to document the usage of `category_id_start` parameter in both basic and advanced usage sections

Additionally, this PR fixes an issue where the file paths were incorrectly formatted in the "file_name" attribute when data is structured in subdirectories. Previously, if an image was located in a subfolder, e.g., `subfolder_1/image.jpeg`, the "file_name" attribute would only contain `image.jpeg` instead of the complete path. This has been fixed to include the full path in the "file_name" attribute.
This resolves #17 